### PR TITLE
fix bare map test descriptions

### DIFF
--- a/test/kromatik/core_test.clj
+++ b/test/kromatik/core_test.clj
@@ -55,12 +55,12 @@
             {:a 1 :b 2 :c 3} [1 2 3])))))
 
 (t/deftest ->bare-map-test
-  (t/testing "all given keys are namespace"
+  (t/testing "all given keys are namespaced"
     (t/is
      (= {:a 1 :b 2}
         (src/->bare-map
          {:xyz/a 1 :zyx/b 2}))))
-  (t/testing "some given keys are namespace"
+  (t/testing "some given keys are namespaced"
     (t/is
      (= {:a 1 :b 2}
         (src/->bare-map


### PR DESCRIPTION
## Summary
- clarify ->bare-map test descriptions by using "namespaced" wording

## Testing
- `clj -M:test` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68988fa9132c832ca523ed1ed5b9cfde