### PR TITLE
migrate core to cljc to support cljs

### DIFF
--- a/src/kromatik/core.cljc
+++ b/src/kromatik/core.cljc
@@ -1,4 +1,12 @@
-(ns kromatik.core)
+(ns kromatik.core
+  #?(:cljs (:refer-clojure :exclude [update-keys])))
+
+#?(:cljs
+   (defn update-keys [m f]
+     (into {}
+           (map (fn [[k v]]
+                  [(f k) v])
+                m))))
 
 (defn combine [k1 k2]
   (if k1

--- a/test/kromatik/core_test.cljc
+++ b/test/kromatik/core_test.cljc
@@ -1,6 +1,8 @@
 (ns kromatik.core-test
+  #?(:cljs (:require-macros [cljs.test :as t]))
   (:require
-   [clojure.test :as t]
+   #?(:clj [clojure.test :as t]
+      :cljs [cljs.test :as t])
    [kromatik.core :as src]))
 
 (t/deftest combine-test


### PR DESCRIPTION
## Summary
- rename source and test namespaces to `.cljc`
- add ClojureScript reader conditionals and `update-keys` polyfill
- make tests work on both JVM and ClojureScript runtimes

## Testing
- `clojure -e "(require 'kromatik.core-test)(clojure.test/run-tests 'kromatik.core-test)"` *(fails: command not found)*
- `curl -O https://download.clojure.org/install/linux-install-1.11.1.1413.sh` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689891cb9aec832cae9c78e8c86b2e9b